### PR TITLE
Feature/json formatting options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ project/target
 **/package-lock.json
 /gatling-results
 bin
+venv

--- a/README.md
+++ b/README.md
@@ -167,11 +167,21 @@ x-proxy-HEADER-NAME: If you need to redirect especific headers to the sending
         destination, you can use this header. Just put the header you need to 
         redirect together with the x-proxy and the value. The system will take these
         headers and plug them into the request to the sending service.
-
-Content-Type: Although not explicitily needed, you usually would use
- 'text/plain' for simple texts  
+Content-Type: Although not explicitily needed, you usually would use ->
+ 'text/plain'               for simple texts  
  'application/octet-stream' for binary data
- 'application/json' for json format
+ 'application/json'         for json format
+
+x-json-format: When using a content type 'application/json', you can also pass this header to better 
+               control the formatting of the incoming json value. ->
+ 'compact' to format the incoming value in a compacted fashion.
+ 'pretty'  to format the incoming value in a more verbose, prettier fashion
+ 'none'    to not perform any formatting
+
+Note:
+ that when the content type is json, the system checks to see if the value is a valid json value.
+ that when by default the formatting option is 'none'
+      
 
 BODY
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,13 @@
             <version>0.7.5</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.lihaoyi/requests -->
+        <dependency>
+            <groupId>com.lihaoyi</groupId>
+            <artifactId>requests_${scala.compat.version}</artifactId>
+            <version>0.6.5</version>
+        </dependency>
+
         <dependency>
             <groupId>org.backuity.clist</groupId>
             <artifactId>clist-core_${scala.compat.version}</artifactId>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,14 +3,14 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.out</target>
         <encoder>
-            <pattern>cat=> %msg%n</pattern>
+            <pattern>[%d{ISO8601}] cat=> %msg%n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
         <encoder>
-            <pattern>cat (err) => %msg%n</pattern>
+            <pattern>[%d{ISO8601}] cat (err) => %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/src/main/scala/com/flatmappable/Catalina.scala
+++ b/src/main/scala/com/flatmappable/Catalina.scala
@@ -78,7 +78,7 @@ object Catalina {
 
   }
 
-  def main(args: Array[String]) = {
+  def main(args: Array[String]): Unit = {
 
     init()
 
@@ -91,7 +91,7 @@ object Catalina {
           "You can verify the micro-certificates after sending, which guaranties that your timestamp is now immutable and trust-enabled. \n\n" +
           "To modify the target stage or environment , run: export CAT_ENV=dev | demo | prod ")
       )
-      .version("0.0.5")
+      .version(version)
       .withCommands(RegisterRandomKey, RegisterKey, GenerateRandomTimestamp, CreateTimestamp, VerifyTimestamp) match {
 
         case Some(GenerateRandomTimestamp) =>

--- a/src/main/scala/com/flatmappable/CatalinaHttp.scala
+++ b/src/main/scala/com/flatmappable/CatalinaHttp.scala
@@ -66,9 +66,12 @@ abstract class CatalinaHttpBase extends cask.MainRoutes with LazyLogging {
             case "compact" => JsonHelper.compact(body)
             case "pretty" => JsonHelper.pretty(body)
             case "none" => JsonHelper.compact(body)
+              .toTry
               .map(_ => (new String(body, StandardCharsets.UTF_8), body))
+              .toEither
           }
           .getOrElse(JsonHelper.compact(body))
+      case "text/plain" => Try(new String(body, StandardCharsets.UTF_8), body).toEither
     }
       .getOrElse(Right("", body))
       .getOrElse(throw BadRequestException("Body is malformed"))

--- a/src/main/scala/com/flatmappable/CatalinaHttp.scala
+++ b/src/main/scala/com/flatmappable/CatalinaHttp.scala
@@ -105,6 +105,9 @@ abstract class CatalinaHttpBase extends cask.MainRoutes with LazyLogging {
       } else if (res.status == KNOWN_UPP) {
         logger.error(s"UPP already known=${toBase64AsString(hash)} Status=${res.status}")
         cask.Response(ResponseMessage(res.status, "KnownUPPError", toBase64AsString(hash)).toJson, res.status)
+      } else if (res.status == UNAUTHORIZED) {
+        logger.error(s"UPP was rejected=${toBase64AsString(hash)} Status=${res.status}")
+        cask.Response(ResponseMessage(res.status, "Unauthorized", toBase64AsString(hash)).toJson, res.status)
       } else {
         logger.error(s"Error Sending UPP=${toBase64AsString(hash)} Status=${res.status}")
         cask.Response(ResponseMessage(res.status, "SendingUPPError", s"Error Sending UPP with Hash=${toBase64AsString(hash)}").toJson, res.status)

--- a/src/main/scala/com/flatmappable/CatalinaHttp.scala
+++ b/src/main/scala/com/flatmappable/CatalinaHttp.scala
@@ -71,6 +71,7 @@ abstract class CatalinaHttpBase extends cask.MainRoutes with LazyLogging {
         .filter { case (k, v) => k.startsWith("x-proxy-") && v.forall(_.nonEmpty) }
         .map { case (k, v) => (k.replaceFirst("x-proxy-", "").trim, v.toSeq.map(_.trim)) }
         .filter { case (k, v) => k.nonEmpty && v.forall(_.nonEmpty) }
+        .filterNot { case (k, v) => k.endsWith("-") || k.startsWith("-") }
 
       val contentType = request.headers
         .filter { case (k, _) => k.startsWith("content-type") }

--- a/src/main/scala/com/flatmappable/CatalinaHttp.scala
+++ b/src/main/scala/com/flatmappable/CatalinaHttp.scala
@@ -1,5 +1,6 @@
 package com.flatmappable
 
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import cask.model.Response
@@ -64,7 +65,7 @@ abstract class CatalinaHttpBase extends cask.MainRoutes with LazyLogging {
             case "compact" => JsonHelper.compact(body)
             case "pretty" => JsonHelper.pretty(body)
             case "none" => JsonHelper.compact(body)
-              .map(_ => ("", body))
+              .map(_ => (new String(body, StandardCharsets.UTF_8), body))
           }
           .getOrElse(JsonHelper.compact(body))
     }

--- a/src/main/scala/com/flatmappable/CatalinaHttp.scala
+++ b/src/main/scala/com/flatmappable/CatalinaHttp.scala
@@ -46,6 +46,7 @@ abstract class CatalinaHttpBase extends cask.MainRoutes with LazyLogging {
 
   private lazy val _configs: String =
     s"""
+     |- VERSION: $version
      |- ENV: ${Configs.ENV}
      |- PORT: ${Configs.CAT_HTTP_PORT}
      |- HOST: $host

--- a/src/main/scala/com/flatmappable/CatalinaHttp.scala
+++ b/src/main/scala/com/flatmappable/CatalinaHttp.scala
@@ -42,6 +42,16 @@ object CatalinaHttp extends cask.MainRoutes with LazyLogging {
       |""".stripMargin
   }
 
+  @cask.get("/configs")
+  def configs() = {
+    s"""
+       |- ENV: ${Configs.ENV}
+       |- PORT: ${Configs.CAT_HTTP_PORT}
+       |- HOST: ${host}
+       |- DATA_SENDING_URL:${Configs.DATA_SENDING_URL}
+       |""".stripMargin
+  }
+
   @cask.post("/send/:uuid")
   def send(uuid: String, request: cask.Request) = {
     try {

--- a/src/main/scala/com/flatmappable/CatalinaHttp.scala
+++ b/src/main/scala/com/flatmappable/CatalinaHttp.scala
@@ -42,15 +42,16 @@ object CatalinaHttp extends cask.MainRoutes with LazyLogging {
       |""".stripMargin
   }
 
-  @cask.get("/configs")
-  def configs() = {
+  private lazy val _configs: String =
     s"""
-       |- ENV: ${Configs.ENV}
-       |- PORT: ${Configs.CAT_HTTP_PORT}
-       |- HOST: ${host}
-       |- DATA_SENDING_URL:${Configs.DATA_SENDING_URL}
-       |""".stripMargin
-  }
+     |- ENV: ${Configs.ENV}
+     |- PORT: ${Configs.CAT_HTTP_PORT}
+     |- HOST: $host
+     |- DATA_SENDING_URL:${Configs.DATA_SENDING_URL}
+     |""".stripMargin
+
+  @cask.get("/configs")
+  def configs() = _configs
 
   @cask.post("/send/:uuid")
   def send(uuid: String, request: cask.Request) = {

--- a/src/main/scala/com/flatmappable/package.scala
+++ b/src/main/scala/com/flatmappable/package.scala
@@ -13,6 +13,8 @@ import org.json4s.{ Formats, NoTypeHints }
 
 package object flatmappable extends LazyLogging {
 
+  final val version = "0.0.5"
+
   implicit lazy val formats: Formats = Serialization.formats(NoTypeHints) ++ org.json4s.ext.JavaTypesSerializers.all
 
   val clock: Clock = Clock.systemUTC

--- a/src/main/scala/com/flatmappable/package.scala
+++ b/src/main/scala/com/flatmappable/package.scala
@@ -72,6 +72,7 @@ package object flatmappable extends LazyLogging {
   def OK: Int = 200
   def MULTIPLE_CHOICE = 300
   def BAD_REQUEST = 400
+  def UNAUTHORIZED = 401
   def CONFLICT = 409
   def KNOWN_UPP: Int = CONFLICT
   def INTERNAL_SERVER_ERROR: Int = 500

--- a/src/main/scala/com/flatmappable/package.scala
+++ b/src/main/scala/com/flatmappable/package.scala
@@ -60,6 +60,13 @@ package object flatmappable extends LazyLogging {
 
   }
 
+  def closableTry[A, B](resource: => A)(cleanup: A => Unit)(code: A => B): Either[Exception, B] = {
+    try {
+      val r = resource
+      try { Right(code(r)) } finally { cleanup(r) }
+    } catch { case e: Exception => Left(e) }
+  }
+
   def now: Long = clock.millis()
 
   def OK: Int = 200

--- a/src/main/scala/com/flatmappable/util/JsonHelper.scala
+++ b/src/main/scala/com/flatmappable/util/JsonHelper.scala
@@ -1,0 +1,40 @@
+package com.flatmappable
+package util
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+import org.json4s.JValue
+import org.json4s.jackson.JsonMethods
+
+import scala.util.Try
+
+object JsonHelper {
+
+  def use(bytes: Array[Byte]): Either[Exception, JValue] = {
+    closableTry(new ByteArrayInputStream(bytes))(_.close()) { is =>
+      JsonMethods.parse(is)
+    }
+  }
+
+  def compact(bytes: Array[Byte]): Either[Throwable, (String, Array[Byte])] = {
+    for {
+      jv <- use(bytes)
+      jvs <- Try(JsonMethods.compact(jv)).toEither
+      b <- Try(jvs.getBytes(StandardCharsets.UTF_8)).toEither
+    } yield {
+      (jvs, b)
+    }
+  }
+
+  def pretty(bytes: Array[Byte]): Either[Throwable, (String, Array[Byte])] = {
+    for {
+      jv <- use(bytes)
+      jvs <- Try(JsonMethods.pretty(jv)).toEither
+      b <- Try(jvs.getBytes(StandardCharsets.UTF_8)).toEither
+    } yield {
+      (jvs, b)
+    }
+  }
+
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,21 +1,21 @@
-<configuration>
+<configuration debug="false">
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.out</target>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%20.20logger{20}] %msg%n</pattern>
+            <pattern>[%d{ISO8601}][%-5level] cat=> %msg%n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%20.20logger{20}] %msg%n</pattern>
+            <pattern>[%d{ISO8601}][%-5level] cat (err) => %msg%n</pattern>
         </encoder>
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="STDERR"/>
+        <appender-ref ref="STDOUT"/>
     </root>
 
 </configuration>

--- a/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
+++ b/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
@@ -158,7 +158,6 @@ class DataSendingHttpSpec extends AnyFunSuite {
 
   }
 
-
   test("CatalinaHttp.send should forward x-proxy headers") {
 
     val cat = new CatalinaHttpBase {
@@ -233,7 +232,7 @@ class DataSendingHttpSpec extends AnyFunSuite {
           "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
           "x-pass" -> "12345678",
           "content-type" -> "application/json"
-         )
+        )
       ))
         .recover { case e: RequestFailedException => e.response }
         .get
@@ -318,7 +317,6 @@ class DataSendingHttpSpec extends AnyFunSuite {
         .recover { case e: RequestFailedException => e.response }
         .get
 
-
       val expected = """{"cities":["New York","Bangalore","San Francisco"],"name":"Pankaj Kumar","age":32}""".stripMargin
       assert(res.statusCode == 200)
       assert(processed == expected)
@@ -329,17 +327,9 @@ class DataSendingHttpSpec extends AnyFunSuite {
 
   test("CatalinaHttp.send should detect json content type header and invalid json") {
 
-    var processed: String = null
-
     val cat = new CatalinaHttpBase {
       override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
         ResponseData(200, Array.empty, Array.empty[Byte])
-      }
-
-      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
-        val (a, b) = super.sendBody(contentType, headers, body)
-        processed = a
-        (a, b)
       }
     }
 
@@ -359,9 +349,138 @@ class DataSendingHttpSpec extends AnyFunSuite {
         .recover { case e: RequestFailedException => e.response }
         .get
 
-
       assert(res.statusCode == 400)
       assert(res.text() == """{"status":400,"message":"BadRequest","data":"Body is malformed"}""")
+
+    }
+
+  }
+
+  test("CatalinaHttp.send should detect json content type header and formatting option none") {
+
+    var processed: String = null
+
+    val cat = new CatalinaHttpBase {
+      override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+        ResponseData(200, Array.empty, Array.empty[Byte])
+      }
+
+      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, headers, body)
+        processed = a
+        (a, b)
+      }
+    }
+
+    withServer(cat) { host =>
+
+      val data = """{"cities": ["New York", "Bangalore","San Francisco"], "name":"Pankaj Kumar","age":32}""".stripMargin
+
+      val res = Try(requests.post(
+        s"$host/send/23949125-e476-4e06-b72c-5dde2cc247b0",
+        data = data,
+        headers = Map(
+          "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
+          "x-pass" -> "12345678",
+          "content-type" -> "application/json",
+          "x-json-format" -> "none"
+        )
+      ))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+      assert(res.statusCode == 200)
+      assert(processed == data)
+
+    }
+
+  }
+
+  test("CatalinaHttp.send should detect json content type header and formatting option compact") {
+
+    var processed: String = null
+
+    val cat = new CatalinaHttpBase {
+      override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+        ResponseData(200, Array.empty, Array.empty[Byte])
+      }
+
+      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, headers, body)
+        processed = a
+        (a, b)
+      }
+    }
+
+    withServer(cat) { host =>
+
+      val data = """{"cities": ["New York", "Bangalore","San Francisco"], "name":"Pankaj Kumar","age":32}""".stripMargin
+
+      val res = Try(requests.post(
+        s"$host/send/23949125-e476-4e06-b72c-5dde2cc247b0",
+        data = data,
+        headers = Map(
+          "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
+          "x-pass" -> "12345678",
+          "content-type" -> "application/json",
+          "x-json-format" -> "compact"
+        )
+      ))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+      val expected = """{"cities":["New York","Bangalore","San Francisco"],"name":"Pankaj Kumar","age":32}""".stripMargin
+      assert(res.statusCode == 200)
+      assert(processed == expected)
+
+    }
+
+  }
+
+  test("CatalinaHttp.send should detect json content type header and formatting option pretty") {
+
+    var processed: String = null
+
+    val cat = new CatalinaHttpBase {
+      override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+        ResponseData(200, Array.empty, Array.empty[Byte])
+      }
+
+      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, headers, body)
+        processed = a
+        (a, b)
+      }
+    }
+
+    withServer(cat) { host =>
+
+      val data = """{"cities": ["New York", "Bangalore","San Francisco"], "name":"Pankaj Kumar","age":32}""".stripMargin
+
+      val res = Try(requests.post(
+        s"$host/send/23949125-e476-4e06-b72c-5dde2cc247b0",
+        data = data,
+        headers = Map(
+          "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
+          "x-pass" -> "12345678",
+          "content-type" -> "application/json",
+          "x-json-format" -> "pretty"
+        )
+      ))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+      val expected =
+        """
+          |{
+          |  "cities" : [ "New York", "Bangalore", "San Francisco" ],
+          |  "name" : "Pankaj Kumar",
+          |  "age" : 32
+          |}
+          |""".stripMargin.trim
+
+      assert(res.statusCode == 200)
+      assert(processed == expected)
 
     }
 

--- a/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
+++ b/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
@@ -159,7 +159,7 @@ class DataSendingHttpSpec extends AnyFunSuite {
   }
 
 
-  test("CatalinaHttp.send should forwarded x-proxy headers") {
+  test("CatalinaHttp.send should forward x-proxy headers") {
 
     val cat = new CatalinaHttpBase {
       override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
@@ -191,6 +191,177 @@ class DataSendingHttpSpec extends AnyFunSuite {
         .get
 
       assert(res.statusCode == 200)
+
+    }
+
+  }
+
+  test("CatalinaHttp.send should detect json content type header but no formatting option") {
+
+    var processed: String = null
+
+    val cat = new CatalinaHttpBase {
+      override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+        ResponseData(200, Array.empty, Array.empty[Byte])
+      }
+
+      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, headers, body)
+        processed = a
+        (a, b)
+      }
+    }
+
+    withServer(cat) { host =>
+
+      val data =
+        """
+          |{
+          |   "cities":[
+          |      "New York",
+          |      "Bangalore",
+          |      "San Francisco"
+          |   ],
+          |   "name":"Pankaj Kumar",
+          |   "age":32
+          |}""".stripMargin
+
+      val res = Try(requests.post(
+        s"$host/send/23949125-e476-4e06-b72c-5dde2cc247b0",
+        data = data,
+        headers = Map(
+          "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
+          "x-pass" -> "12345678",
+          "content-type" -> "application/json"
+         )
+      ))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+      val expected = """{"cities":["New York","Bangalore","San Francisco"],"name":"Pankaj Kumar","age":32}""".stripMargin
+
+      assert(res.statusCode == 200)
+      assert(processed == expected)
+
+    }
+
+  }
+
+  test("CatalinaHttp.send should detect json content type header but no formatting option 2") {
+
+    var processed: String = null
+
+    val cat = new CatalinaHttpBase {
+      override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+        ResponseData(200, Array.empty, Array.empty[Byte])
+      }
+
+      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, headers, body)
+        processed = a
+        (a, b)
+      }
+    }
+
+    withServer(cat) { host =>
+
+      val data = """{"cities":["New York","Bangalore","San Francisco"],"name":"Pankaj Kumar","age":32}""".stripMargin
+
+      val res = Try(requests.post(
+        s"$host/send/23949125-e476-4e06-b72c-5dde2cc247b0",
+        data = data,
+        headers = Map(
+          "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
+          "x-pass" -> "12345678",
+          "content-type" -> "application/json"
+        )
+      ))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+      assert(res.statusCode == 200)
+      assert(processed == data)
+
+    }
+
+  }
+
+  test("CatalinaHttp.send should detect json content type header but no formatting option 3") {
+
+    var processed: String = null
+
+    val cat = new CatalinaHttpBase {
+      override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+        ResponseData(200, Array.empty, Array.empty[Byte])
+      }
+
+      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, headers, body)
+        processed = a
+        (a, b)
+      }
+    }
+
+    withServer(cat) { host =>
+
+      val data = """{"cities": ["New York","Bangalore","San Francisco"], "name":"Pankaj Kumar","age":32}""".stripMargin
+
+      val res = Try(requests.post(
+        s"$host/send/23949125-e476-4e06-b72c-5dde2cc247b0",
+        data = data,
+        headers = Map(
+          "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
+          "x-pass" -> "12345678",
+          "content-type" -> "application/json"
+        )
+      ))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+
+      val expected = """{"cities":["New York","Bangalore","San Francisco"],"name":"Pankaj Kumar","age":32}""".stripMargin
+      assert(res.statusCode == 200)
+      assert(processed == expected)
+
+    }
+
+  }
+
+  test("CatalinaHttp.send should detect json content type header and invalid json") {
+
+    var processed: String = null
+
+    val cat = new CatalinaHttpBase {
+      override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+        ResponseData(200, Array.empty, Array.empty[Byte])
+      }
+
+      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, headers, body)
+        processed = a
+        (a, b)
+      }
+    }
+
+    withServer(cat) { host =>
+
+      val data = """{"cities": ["New York""Bangalore","San Francisco"], "name":"Pankaj Kumar","age":32}""".stripMargin
+
+      val res = Try(requests.post(
+        s"$host/send/23949125-e476-4e06-b72c-5dde2cc247b0",
+        data = data,
+        headers = Map(
+          "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
+          "x-pass" -> "12345678",
+          "content-type" -> "application/json"
+        )
+      ))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+
+      assert(res.statusCode == 400)
+      assert(res.text() == """{"status":400,"message":"BadRequest","data":"Body is malformed"}""")
 
     }
 

--- a/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
+++ b/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
@@ -503,4 +503,126 @@ class DataSendingHttpSpec extends AnyFunSuite {
 
   }
 
+  test("CatalinaHttp.send should detect json with maybe special character") {
+
+    var processed: String = null
+
+    val cat = new CatalinaHttpBase {
+      override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+        ResponseData(200, Array.empty, Array.empty[Byte])
+      }
+
+      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, headers, body)
+        processed = a
+        (a, b)
+      }
+    }
+
+    withServer(cat) { host =>
+
+      val data = """{"data":"verfügbar, nämlich"}""".stripMargin
+
+      val res = Try(requests.post(
+        s"$host/send/23949125-e476-4e06-b72c-5dde2cc247b0",
+        data = data,
+        headers = Map(
+          "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
+          "x-pass" -> "12345678",
+          "content-type" -> "application/json"
+        )
+      ))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+      assert(res.statusCode == 200)
+      assert(processed == data)
+
+    }
+
+  }
+
+  test("CatalinaHttp.send should detect text with maybe special character") {
+
+    var processed: String = null
+
+    val cat = new CatalinaHttpBase {
+      override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+        ResponseData(200, Array.empty, Array.empty[Byte])
+      }
+
+      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, headers, body)
+        processed = a
+        (a, b)
+      }
+    }
+
+    withServer(cat) { host =>
+
+      val data = """{"data":"verfügbar, nämlich"}""".stripMargin
+
+      val res = Try(requests.post(
+        s"$host/send/23949125-e476-4e06-b72c-5dde2cc247b0",
+        data = data,
+        headers = Map(
+          "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
+          "x-pass" -> "12345678",
+          "content-type" -> "text/plain"
+        )
+      ))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+      assert(res.statusCode == 200)
+      assert(processed == data)
+
+    }
+
+  }
+
+  test("CatalinaHttp.send should detect text") {
+
+    var processed: String = null
+
+    val cat = new CatalinaHttpBase {
+      override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+        ResponseData(200, Array.empty, Array.empty[Byte])
+      }
+
+      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, headers, body)
+        processed = a
+        (a, b)
+      }
+    }
+
+    withServer(cat) { host =>
+
+      val data =
+        """
+          |Ein Automobil, kurz Auto (auch Kraftwagen, in der Schweiz amtlich Motorwagen), ist ein mehrspuriges Kraftfahrzeug (also ein von einem Motor angetriebenes Straßenfahrzeug), das zur Beförderung von Personen (Personenkraftwagen „Pkw“ und Bus) oder Frachtgütern (Lastkraftwagen „Lkw“) dient. Umgangssprachlich – und auch in diesem Artikel – werden mit dem Begriff Auto meist Fahrzeuge bezeichnet, deren Bauart überwiegend zur Personenbeförderung bestimmt ist und die mit einem Automobil-Führerschein auf öffentlichem Verkehrsgrund geführt werden dürfen.
+          |
+          |Der weltweite Fahrzeugbestand steigt kontinuierlich an und lag im Jahr 2010 bei über 1,015 Milliarden Automobilen. 2011 wurden weltweit über 80 Millionen Automobile gebaut. In Deutschland waren im Jahr 2012 etwa 51,7 Millionen Kraftfahrzeuge zugelassen, davon sind knapp 43 Millionen Personenkraftwagen.
+          |""".stripMargin
+
+      val res = Try(requests.post(
+        s"$host/send/23949125-e476-4e06-b72c-5dde2cc247b0",
+        data = data,
+        headers = Map(
+          "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
+          "x-pass" -> "12345678",
+          "content-type" -> "text/plain"
+        )
+      ))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+      assert(res.statusCode == 200)
+      assert(processed == data)
+
+    }
+
+  }
+
 }

--- a/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
+++ b/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
@@ -1,0 +1,72 @@
+package com.flatmappable
+
+import java.util.UUID
+
+import com.flatmappable.util.ResponseData
+import io.undertow.Undertow
+import org.scalatest.funsuite.AnyFunSuite
+import requests.RequestFailedException
+
+import scala.util.Try
+
+class DataSendingHttpSpec extends AnyFunSuite {
+
+  def withServer[T](example: cask.main.Main)(f: String => T): T = {
+    val server = Undertow.builder
+      .addHttpListener(8081, CatalinaHttp.host)
+      .setHandler(example.defaultHandler)
+      .build
+    server.start()
+    val res =
+      try f("http://localhost:8081")
+      finally server.stop()
+    res
+
+  }
+
+  test("CatalinaHttp.configs should exist") {
+
+    withServer(CatalinaHttp) { host =>
+
+      val res = requests.get(s"$host/configs").statusCode
+      assert(res == 200)
+
+    }
+
+  }
+
+  test("CatalinaHttp should exist") {
+
+    withServer(CatalinaHttp) { host =>
+
+      val res = requests.get(s"$host").statusCode
+      assert(res == 200)
+
+    }
+
+  }
+
+  class Cat() extends CatalinaHttpBase {
+    override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+      ResponseData(200, Array.empty, hash)
+    }
+  }
+
+  test("CatalinaHttp.send should fail when no body is sent") {
+
+    withServer(new Cat()) { host =>
+
+      val uuid = UUID.randomUUID()
+
+      val res = Try(requests.post(s"$host/send/$uuid"))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+      assert(res.statusCode == 400)
+      assert(res.text() == """{"status":400,"message":"BadRequest","data":"Empty body"}""")
+
+    }
+
+  }
+
+}

--- a/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
+++ b/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
@@ -2,6 +2,7 @@ package com.flatmappable
 
 import java.util.UUID
 
+import com.flatmappable.util.ResponseData
 import io.undertow.Undertow
 import org.scalatest.funsuite.AnyFunSuite
 import requests.{ RequestFailedException, headers }
@@ -126,6 +127,32 @@ class DataSendingHttpSpec extends AnyFunSuite {
 
       assert(res.statusCode == 500)
       assert(res.text() == """{"status":500,"message":"InternalError","data":""}""")
+
+    }
+
+  }
+
+  test("CatalinaHttp.send should fail wh") {
+
+    val cat = new CatalinaHttpBase {
+      override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+        ResponseData(401, Array.empty, Array.empty)
+      }
+    }
+
+    withServer(cat) { host =>
+
+      val data = """{"cities":["New York","Bangalore","San Francisco"],"name":"Pankaj Kumar","age":32}""".stripMargin
+
+      val res = Try(requests.post(
+        s"$host/send/23949125-e476-4e06-b72c-5dde2cc247b0",
+        data = data,
+        headers = Map("x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=", "x-pass" -> "12345678")
+      ))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+      assert(res.statusCode == 401)
 
     }
 

--- a/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
+++ b/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
@@ -1,5 +1,6 @@
 package com.flatmappable
 
+import java.nio.charset.{ Charset, StandardCharsets }
 import java.util.UUID
 
 import com.flatmappable.util.ResponseData
@@ -221,8 +222,8 @@ class DataSendingHttpSpec extends AnyFunSuite {
         ResponseData(200, Array.empty, Array.empty[Byte])
       }
 
-      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
-        val (a, b) = super.sendBody(contentType, headers, body)
+      override protected def sendBody(contentType: Option[String], charset: Option[Charset], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, charset, headers, body)
         processed = a
         (a, b)
       }
@@ -272,8 +273,8 @@ class DataSendingHttpSpec extends AnyFunSuite {
         ResponseData(200, Array.empty, Array.empty[Byte])
       }
 
-      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
-        val (a, b) = super.sendBody(contentType, headers, body)
+      override protected def sendBody(contentType: Option[String], charset: Option[Charset], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, charset, headers, body)
         processed = a
         (a, b)
       }
@@ -311,8 +312,8 @@ class DataSendingHttpSpec extends AnyFunSuite {
         ResponseData(200, Array.empty, Array.empty[Byte])
       }
 
-      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
-        val (a, b) = super.sendBody(contentType, headers, body)
+      override protected def sendBody(contentType: Option[String], charset: Option[Charset], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, charset, headers, body)
         processed = a
         (a, b)
       }
@@ -382,8 +383,8 @@ class DataSendingHttpSpec extends AnyFunSuite {
         ResponseData(200, Array.empty, Array.empty[Byte])
       }
 
-      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
-        val (a, b) = super.sendBody(contentType, headers, body)
+      override protected def sendBody(contentType: Option[String], charset: Option[Charset], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, charset, headers, body)
         processed = a
         (a, b)
       }
@@ -422,8 +423,8 @@ class DataSendingHttpSpec extends AnyFunSuite {
         ResponseData(200, Array.empty, Array.empty[Byte])
       }
 
-      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
-        val (a, b) = super.sendBody(contentType, headers, body)
+      override protected def sendBody(contentType: Option[String], charset: Option[Charset], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, charset, headers, body)
         processed = a
         (a, b)
       }
@@ -463,8 +464,8 @@ class DataSendingHttpSpec extends AnyFunSuite {
         ResponseData(200, Array.empty, Array.empty[Byte])
       }
 
-      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
-        val (a, b) = super.sendBody(contentType, headers, body)
+      override protected def sendBody(contentType: Option[String], charset: Option[Charset], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, charset, headers, body)
         processed = a
         (a, b)
       }
@@ -512,8 +513,8 @@ class DataSendingHttpSpec extends AnyFunSuite {
         ResponseData(200, Array.empty, Array.empty[Byte])
       }
 
-      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
-        val (a, b) = super.sendBody(contentType, headers, body)
+      override protected def sendBody(contentType: Option[String], charset: Option[Charset], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, charset, headers, body)
         processed = a
         (a, b)
       }
@@ -551,8 +552,8 @@ class DataSendingHttpSpec extends AnyFunSuite {
         ResponseData(200, Array.empty, Array.empty[Byte])
       }
 
-      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
-        val (a, b) = super.sendBody(contentType, headers, body)
+      override protected def sendBody(contentType: Option[String], charset: Option[Charset], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, charset, headers, body)
         processed = a
         (a, b)
       }
@@ -590,8 +591,8 @@ class DataSendingHttpSpec extends AnyFunSuite {
         ResponseData(200, Array.empty, Array.empty[Byte])
       }
 
-      override protected def sendBody(contentType: Option[String], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
-        val (a, b) = super.sendBody(contentType, headers, body)
+      override protected def sendBody(contentType: Option[String], charset: Option[Charset], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, charset, headers, body)
         processed = a
         (a, b)
       }
@@ -613,6 +614,45 @@ class DataSendingHttpSpec extends AnyFunSuite {
           "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
           "x-pass" -> "12345678",
           "content-type" -> "text/plain"
+        )
+      ))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+      assert(res.statusCode == 200)
+      assert(processed == data)
+
+    }
+
+  }
+
+  test("CatalinaHttp.send should detect text with charset") {
+
+    var processed: String = null
+
+    val cat = new CatalinaHttpBase {
+      override def sendData(uuid: UUID, password: String, hash: Array[Byte], upp: Array[Byte], extraHeaders: Map[String, Seq[String]]): ResponseData[Array[Byte]] = {
+        ResponseData(200, Array.empty, Array.empty[Byte])
+      }
+
+      override protected def sendBody(contentType: Option[String], charset: Option[Charset], headers: Map[String, collection.Seq[String]], body: Array[Byte]): (String, Array[Byte]) = {
+        val (a, b) = super.sendBody(contentType, charset, headers, body)
+        processed = a
+        (a, b)
+      }
+    }
+
+    withServer(cat) { host =>
+
+      val data = "hola"
+
+      val res = Try(requests.post(
+        s"$host/send/23949125-e476-4e06-b72c-5dde2cc247b0",
+        data = data.getBytes(StandardCharsets.US_ASCII),
+        headers = Map(
+          "x-pk" -> "hcOakLL7KO6XmsdZYQdb9uZeO5/IwxqmgAudIzXQpgE=",
+          "x-pass" -> "12345678",
+          "content-type" -> "text/plain; charset=US-ASCII"
         )
       ))
         .recover { case e: RequestFailedException => e.response }

--- a/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
+++ b/src/test/scala/com/flatmappable/DataSendingHttpSpec.scala
@@ -46,6 +46,23 @@ class DataSendingHttpSpec extends AnyFunSuite {
 
   }
 
+  test("CatalinaHttp.send should fail when invalid uuid is detected") {
+
+    val cat = new CatalinaHttpBase {}
+
+    withServer(cat) { host =>
+
+      val res = Try(requests.post(s"$host/send/123456"))
+        .recover { case e: RequestFailedException => e.response }
+        .get
+
+      assert(res.statusCode == 400)
+      assert(res.text() == """{"status":400,"message":"BadRequest","data":"Invalid uuid"}""")
+
+    }
+
+  }
+
   test("CatalinaHttp.send should fail when no body is sent") {
 
     val cat = new CatalinaHttpBase {}


### PR DESCRIPTION
Adding support to specify the formatting for when the content type is json:
- pretty 
- compact
- none

Adding multiple tests for the Catalina HTTP